### PR TITLE
update path used for win10 updates

### DIFF
--- a/scripts/ms/mswin/buildnumbers.ps1
+++ b/scripts/ms/mswin/buildnumbers.ps1
@@ -1,8 +1,8 @@
-$rootPages = @("https://aka.ms/WindowsUpdateHistory",
+$rootPages = @("https://support.microsoft.com/en-us/topic/windows-10-update-history-24ea91f4-36e7-d8fd-0ddb-d79d9d0cdbda",
                "https://aka.ms/Windows11UpdateHistory",
                "https://support.microsoft.com/en-us/topic/windows-server-2022-update-history-e1caa597-00c5-4ab9-9f3e-8212fe80b2ee")
 
-$d4nData = Invoke-WebRequest "https://raw.datafornerds.io/ms/mswin/buildnumbers.json" | Select-Object -ExpandProperty Content | ConvertFrom-Json
+$d4nData = Invoke-WebRequest "https://raw.githubusercontent.com/altrhombus/ReportSource/main/content/ms/mswin/buildnumbers.json" | Select-Object -ExpandProperty Content | ConvertFrom-Json
 
 $patchList = New-Object System.Collections.ArrayList
 


### PR DESCRIPTION
resolves an issue where all win10 updates were removed from the buildnumbers.json. the aka.ms link now points to win11 updates, so the script now references the win10 updates directly.