### PR TITLE
add windows client and server OS lifecycle datasets

### DIFF
--- a/.github/workflows/ms-mswin-update-lifecycle-client.yml
+++ b/.github/workflows/ms-mswin-update-lifecycle-client.yml
@@ -1,0 +1,30 @@
+name: ms-mswin-update-lifecycle-client (Update)
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+      - name: Run the PowerShell Script
+        shell: pwsh
+        run: ./scripts/ms/mswin/lifecycle-client.ps1
+      - name: Submit a Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Updated Microsoft Windows client lifecycle JSON
+          committer: GitHub <noreply@github.com>
+          branch: au/ms-mswin-update-lifecycle-client
+          delete-branch: true
+          title: Automatic Update of Windows client lifecycle
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          

--- a/.github/workflows/ms-mswin-update-lifecycle-server.yml
+++ b/.github/workflows/ms-mswin-update-lifecycle-server.yml
@@ -1,0 +1,30 @@
+name: ms-mswin-update-lifecycle-server (Update)
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v2
+      - name: Run the PowerShell Script
+        shell: pwsh
+        run: ./scripts/ms/mswin/lifecycle-server.ps1
+      - name: Submit a Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Updated Microsoft Windows server lifecycle JSON
+          committer: GitHub <noreply@github.com>
+          branch: au/ms-mswin-update-lifecycle-server
+          delete-branch: true
+          title: Automatic Update of Windows server lifecycle
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+          

--- a/content/ms/mswin/lifecycle-client.json
+++ b/content/ms/mswin/lifecycle-client.json
@@ -1,0 +1,25 @@
+{
+  "DataForNerds": {
+    "LastUpdatedUTC": "2024-03-14T03:22:39.1938945Z",
+    "SourceList": [
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education"
+    ]
+  },
+  "Data": [
+    {
+      "Version": "21H2",
+      "StartDate": "2021-10-04",
+      "EndDate": "2021-10-04"
+    },
+    {
+      "Version": "22H2",
+      "StartDate": "2022-09-20",
+      "EndDate": "2022-09-20"
+    },
+    {
+      "Version": "23H2",
+      "StartDate": "2023-10-31",
+      "EndDate": "2023-10-31"
+    }
+  ]
+}

--- a/content/ms/mswin/lifecycle-server.json
+++ b/content/ms/mswin/lifecycle-server.json
@@ -1,0 +1,58 @@
+{
+  "DataForNerds": {
+    "LastUpdatedUTC": "2024-03-14T03:22:32.1498512Z",
+    "SourceList": [
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019",
+      "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022"
+    ]
+  },
+  "Data": [
+    {
+      "Version": "Windows Server 2008",
+      "StartDate": "2008-05-06",
+      "MainstreamEndDate": "2015-01-14",
+      "ExtendedEndDate": "2020-01-15"
+    },
+    {
+      "Version": "Windows Server 2008 R2",
+      "StartDate": "2009-10-22",
+      "MainstreamEndDate": "2015-01-14",
+      "ExtendedEndDate": "2020-01-15"
+    },
+    {
+      "Version": "Windows Server 2012",
+      "StartDate": "2012-10-30",
+      "MainstreamEndDate": "2018-10-10",
+      "ExtendedEndDate": "2023-10-11"
+    },
+    {
+      "Version": "Windows Server 2012 R2",
+      "StartDate": "2013-11-25",
+      "MainstreamEndDate": "2018-10-10",
+      "ExtendedEndDate": "2023-10-11"
+    },
+    {
+      "Version": "Windows Server 2016",
+      "StartDate": "2016-10-15",
+      "MainstreamEndDate": "2022-01-12",
+      "ExtendedEndDate": "2027-01-13"
+    },
+    {
+      "Version": "Windows Server 2019",
+      "StartDate": "2018-11-13",
+      "MainstreamEndDate": "2024-01-10",
+      "ExtendedEndDate": "2029-01-10"
+    },
+    {
+      "Version": "Windows Server 2022",
+      "StartDate": "2021-08-18",
+      "MainstreamEndDate": "2026-10-14",
+      "ExtendedEndDate": "2031-10-15"
+    }
+  ]
+}

--- a/scripts/ms/mswin/lifecycle-client.ps1
+++ b/scripts/ms/mswin/lifecycle-client.ps1
@@ -1,0 +1,40 @@
+$msdata = @("https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education")
+$d4nData = Invoke-WebRequest "https://raw.datafornerds.io/ms/mswin/lifecycle-client.json" | Select-Object -ExpandProperty Content | ConvertFrom-Json
+
+$releaseList = New-Object System.Collections.ArrayList
+
+foreach ($sourceURL in $msdata) {
+    $source = Invoke-WebRequest $sourceURL -UseBasicParsing
+    $allReleases = [RegEx]::New(('<td>Version (.*?)<\/td>\s*<td align="right">\s*<local-time timezone="America\/Los_Angeles" format="date" datetime="(.*?)">(.*?)<\/local-time>\s*<\/td>\s*<td align="right">\s*<local-time timezone="America\/Los_Angeles" format="date" datetime="(.*?)">(.*?)<\/local-time>')).Matches($source.RawContent)
+    $allReleases.ForEach{
+        $releaseList.add(
+            [PSCustomObject]@{
+                Version = $_.Groups[1].value
+                StartDate = $(Get-Date $_.Groups[2].Value -Format "yyyy-MM-dd")
+                EndDate = $(Get-Date $_.Groups[3].Value -Format "yyyy-MM-dd")
+            }
+        ) | Out-Null
+    }
+}
+
+$releaseList = $releaseList | Sort-Object Version | Select-Object Version,StartDate,EndDate -Unique
+
+$outputData = [PSCustomObject]@{
+    "DataForNerds"=[PSCustomObject]@{
+        "LastUpdatedUTC" = (Get-Date).ToUniversalTime()
+        "SourceList" = @("https://learn.microsoft.com/en-us/lifecycle/products/windows-11-enterprise-and-education")
+    }
+    "Data" = $releaseList
+}
+
+$allProperties = $releaseList[0].psobject.Properties.Name
+
+If(Compare-Object $d4nData.Data $releaseList -Property $allProperties -SyncWindow 0) {
+    $outputFolder = Resolve-Path (Join-Path $PSScriptRoot -ChildPath "../../../content/ms/mswin")
+    $outputFile = Join-Path $outputFolder -ChildPath "lifecycle-client.json"
+
+    $jsonData = $outputData | ConvertTo-Json
+    [System.IO.File]::WriteAllLines($outputFile, $jsonData)   
+} else {
+    Write-Host "The data has not changed."
+}

--- a/scripts/ms/mswin/lifecycle-server.ps1
+++ b/scripts/ms/mswin/lifecycle-server.ps1
@@ -1,0 +1,41 @@
+$msdata = @("https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022")
+$d4nData = Invoke-WebRequest "https://raw.datafornerds.io/ms/mswin/lifecycle-server.json" | Select-Object -ExpandProperty Content | ConvertFrom-Json
+
+$releaseList = New-Object System.Collections.ArrayList
+
+foreach ($sourceURL in $msdata) {
+    $source = Invoke-WebRequest $sourceURL -UseBasicParsing
+    $allReleases = [RegEx]::New(('<td>(.*?)<\/td>\s*<td align="right">\s*<local-time timezone="America\/Los_Angeles" format="date" datetime="(.*?)">(.*?)<\/local-time>\s*<\/td>\s*<td align="right">\s*<local-time timezone="America\/Los_Angeles" format="date" datetime="(.*?)">(.*?)<\/local-time>\s*<\/td>\s*<td align="right">\s*<local-time timezone="America\/Los_Angeles" format="date" datetime="(.*?)">(.*?)<\/local-time>')).Matches($source.RawContent)
+    $allReleases.ForEach{
+        $releaseList.add(
+            [PSCustomObject]@{
+                Version = $_.Groups[1].value
+                StartDate = $(Get-Date $_.Groups[2].Value -Format "yyyy-MM-dd")
+                MainstreamEndDate = $(Get-Date $_.Groups[4].Value -Format "yyyy-MM-dd")
+                ExtendedEndDate = $(Get-Date $_.Groups[6].Value -Format "yyyy-MM-dd")
+            }
+        ) | Out-Null
+    }
+}
+
+$releaseList = $releaseList | Sort-Object Version | Select-Object Version,StartDate,MainstreamEndDate,ExtendedEndDate -Unique
+
+$outputData = [PSCustomObject]@{
+    "DataForNerds"=[PSCustomObject]@{
+        "LastUpdatedUTC" = (Get-Date).ToUniversalTime()
+        "SourceList" = @("https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2008-r2", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2012-r2", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2016", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2019", "https://learn.microsoft.com/en-us/lifecycle/products/windows-server-2022")
+    }
+    "Data" = $releaseList
+}
+
+$allProperties = $releaseList[0].psobject.Properties.Name
+
+If(Compare-Object $d4nData.Data $releaseList -Property $allProperties -SyncWindow 0) {
+    $outputFolder = Resolve-Path (Join-Path $PSScriptRoot -ChildPath "../../../content/ms/mswin")
+    $outputFile = Join-Path $outputFolder -ChildPath "lifecycle-server.json"
+
+    $jsonData = $outputData | ConvertTo-Json
+    [System.IO.File]::WriteAllLines($outputFile, $jsonData)   
+} else {
+    Write-Host "The data has not changed."
+}


### PR DESCRIPTION
these scripts gather the lifecycle dates from https://learn.microsoft.com/en-us/lifecycle/products for clients (windows 11) and servers (server 2008r2 through 2022). for clients, the EOS date for the enterprise/education sku is noted. for servers, the mainstream and extended end dates are noted.